### PR TITLE
Correctly download llama.cpp submodule

### DIFF
--- a/.github/workflows/publish-mavencentral.yml
+++ b/.github/workflows/publish-mavencentral.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Select Xcode
         run: |


### PR DESCRIPTION
When trying to publish on Maven Central it fails because it does not find the submodule because it is not downloaded. 