### PR TITLE
Removed Compose dependency from library

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,8 +3,6 @@ import org.gradle.jvm.tasks.Jar
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.compose.compiler)
-    id("org.jetbrains.compose")
     id("com.android.library")
     id("org.jetbrains.dokka") version "2.1.0"
     id("maven-publish")
@@ -554,10 +552,6 @@ kotlin {
     tasks.matching { it.name == "wasmJsProcessResources" }.configureEach {
         dependsOn(copyLlamatikWasmToResources)
     }
-}
-
-compose.resources {
-    publicResClass = true
 }
 
 extensions.configure<LibraryExtension> {

--- a/library/src/androidMain/kotlin/com/llamatik/library/platform/LlamaBridge.android.kt
+++ b/library/src/androidMain/kotlin/com/llamatik/library/platform/LlamaBridge.android.kt
@@ -1,33 +1,14 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-import java.io.File
-
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual object LlamaBridge {
     init {
         System.loadLibrary("llama_jni") // Only here, where System exists
     }
 
+    actual fun getModelPath(modelFileName: String): String = modelFileName
     actual external fun initEmbedModel(modelPath: String): Boolean
     actual external fun embed(input: String): FloatArray
-
-    @Composable
-    actual fun getModelPath(modelFileName: String): String {
-        val context = LocalContext.current
-        val outFile = File(context.cacheDir, modelFileName)
-
-        if (!outFile.exists()) {
-            context.assets.open(modelFileName).use { inputStream ->
-                outFile.outputStream().use { outputStream ->
-                    inputStream.copyTo(outputStream)
-                }
-            }
-        }
-
-        return outFile.absolutePath
-    }
 
     actual external fun initGenerateModel(modelPath: String): Boolean
     actual external fun generate(prompt: String): String

--- a/library/src/androidMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.android.kt
+++ b/library/src/androidMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.android.kt
@@ -1,27 +1,12 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-import java.io.File
-
 actual object StableDiffusionBridge {
     init {
         // Single native shared library for all JNI bridges (llama/whisper/sd).
         System.loadLibrary("llama_jni")
     }
 
-    @Composable
-    actual fun getModelPath(modelFileName: String): String {
-        // Same behavior as WhisperBridge: copy model from assets to cache if needed.
-        val context = LocalContext.current
-        val outFile = File(context.cacheDir, modelFileName)
-        if (!outFile.exists()) {
-            context.assets.open(modelFileName).use { input ->
-                outFile.outputStream().use { output -> input.copyTo(output) }
-            }
-        }
-        return outFile.absolutePath
-    }
+    actual fun getModelPath(modelFileName: String): String = modelFileName
 
     actual external fun initModel(modelPath: String, threads: Int): Boolean
 

--- a/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
+++ b/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
@@ -1,26 +1,11 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-import java.io.File
-
 actual object WhisperBridge {
     init {
         System.loadLibrary("llama_jni")
     }
 
-    @Composable
-    actual fun getModelPath(modelFileName: String): String {
-        val context = LocalContext.current
-        val outFile = File(context.cacheDir, modelFileName)
-        if (!outFile.exists()) {
-            context.assets.open(modelFileName).use { input ->
-                outFile.outputStream().use { output -> input.copyTo(output) }
-            }
-        }
-        return outFile.absolutePath
-    }
-
+    actual fun getModelPath(modelFileName: String): String = modelFileName
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?): String
     actual external fun release()

--- a/library/src/commonMain/kotlin/com/llamatik/library/platform/LlamaBridge.kt
+++ b/library/src/commonMain/kotlin/com/llamatik/library/platform/LlamaBridge.kt
@@ -1,12 +1,8 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect object LlamaBridge {
-    @Composable
     fun getModelPath(modelFileName: String): String
-
     fun initEmbedModel(modelPath: String): Boolean
     fun embed(input: String): FloatArray
     fun initGenerateModel(modelPath: String): Boolean

--- a/library/src/commonMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.kt
+++ b/library/src/commonMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.kt
@@ -1,7 +1,5 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-
 /**
  * Minimal Stable Diffusion bridge backed by leejet/stable-diffusion.cpp.
  *
@@ -11,7 +9,7 @@ import androidx.compose.runtime.Composable
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect object StableDiffusionBridge {
-    @Composable
+
     fun getModelPath(modelFileName: String): String
 
     /**

--- a/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
+++ b/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
@@ -1,10 +1,7 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect object WhisperBridge {
-    @Composable
     fun getModelPath(modelFileName: String): String
 
     fun initModel(modelPath: String): Boolean

--- a/library/src/iosArm64Main/kotlin/com/llamatik/library/platform/LlamaBridge.iosArm64.kt
+++ b/library/src/iosArm64Main/kotlin/com/llamatik/library/platform/LlamaBridge.iosArm64.kt
@@ -2,7 +2,6 @@
 
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import com.llamatik.library.platform.llama.llama_embed
 import com.llamatik.library.platform.llama.llama_embed_free
 import com.llamatik.library.platform.llama.llama_embed_init
@@ -44,7 +43,6 @@ import platform.Foundation.writeToURL
 actual object LlamaBridge {
 
     @OptIn(ExperimentalResourceApi::class, BetaInteropApi::class)
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         val fm = NSFileManager.defaultManager
         val cachesDir = fm.URLsForDirectory(NSCachesDirectory, NSUserDomainMask).first() as NSURL

--- a/library/src/iosMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.ios.kt
+++ b/library/src/iosMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.ios.kt
@@ -2,7 +2,6 @@
 
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.llamatik.library.platform.sd.sd_free_bytes
 import com.llamatik.library.platform.sd.sd_init
@@ -21,7 +20,6 @@ actual object StableDiffusionBridge {
 
     private var isInitialized = false
 
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         // iOS app manages download/path. Keep consistent with your other bridges.
         return remember(modelFileName) { modelFileName }

--- a/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
+++ b/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
@@ -1,6 +1,5 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import com.llamatik.library.platform.whisper.whisper_stt_free_string
 import com.llamatik.library.platform.whisper.whisper_stt_init
 import com.llamatik.library.platform.whisper.whisper_stt_release
@@ -12,7 +11,6 @@ import platform.Foundation.NSLog
 
 actual object WhisperBridge {
 
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         // Not really used anymore now that models are downloaded,
         // but keep the signature for API symmetry.

--- a/library/src/iosSimulatorArm64Main/kotlin/com/llamatik/library/platform/LlamaBridge.iosSimulatorArm64.kt
+++ b/library/src/iosSimulatorArm64Main/kotlin/com/llamatik/library/platform/LlamaBridge.iosSimulatorArm64.kt
@@ -2,7 +2,6 @@
 
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import com.llamatik.library.platform.llama.llama_embed
 import com.llamatik.library.platform.llama.llama_embed_free
 import com.llamatik.library.platform.llama.llama_embed_init
@@ -44,7 +43,6 @@ import platform.Foundation.writeToURL
 actual object LlamaBridge {
 
     @OptIn(ExperimentalResourceApi::class, BetaInteropApi::class)
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         val fm = NSFileManager.defaultManager
         val cachesDir = fm.URLsForDirectory(NSCachesDirectory, NSUserDomainMask).first() as NSURL

--- a/library/src/iosX64Main/kotlin/com/llamatik/library/platform/LlamaBridge.iosX64.kt
+++ b/library/src/iosX64Main/kotlin/com/llamatik/library/platform/LlamaBridge.iosX64.kt
@@ -2,7 +2,6 @@
 
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import com.llamatik.library.platform.llama.llama_embed
 import com.llamatik.library.platform.llama.llama_embed_free
 import com.llamatik.library.platform.llama.llama_embed_init
@@ -44,7 +43,6 @@ import platform.Foundation.writeToURL
 actual object LlamaBridge {
 
     @OptIn(ExperimentalResourceApi::class, BetaInteropApi::class)
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         val fm = NSFileManager.defaultManager
         val cachesDir = fm.URLsForDirectory(NSCachesDirectory, NSUserDomainMask).first() as NSURL

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/LlamaBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/LlamaBridge.jvm.kt
@@ -2,7 +2,6 @@
 
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import java.io.File
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
@@ -20,7 +19,6 @@ actual object LlamaBridge {
      * On JVM / desktop we assume [modelFileName] is already an absolute path,
      * e.g. the value coming from LlamatikTempFile.absolutePath().
      */
-    @Composable
     actual fun getModelPath(modelFileName: String): String = modelFileName
 
     actual external fun initGenerateModel(modelPath: String): Boolean

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.jvm.kt
@@ -1,6 +1,5 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import java.io.File
 import java.nio.file.Files
 import kotlin.io.path.Path
@@ -11,7 +10,6 @@ actual object StableDiffusionBridge {
         loadNativeFromResources()
     }
 
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         // Desktop: callers typically pass an absolute path to downloaded model files.
         val p = Path(modelFileName)

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
@@ -1,6 +1,5 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import java.io.File
 import java.nio.file.Files
 import kotlin.io.path.Path
@@ -12,7 +11,6 @@ actual object WhisperBridge {
         loadNativeFromResources()
     }
 
-    @Composable
     actual fun getModelPath(modelFileName: String): String {
         // Desktop: expect models to exist on disk (downloaded).
         // Return as-is if caller passes an absolute path; otherwise resolve from working dir.

--- a/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/LlamaBridge.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/LlamaBridge.wasmJs.kt
@@ -2,7 +2,6 @@
 
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,7 +19,6 @@ actual object LlamaBridge {
     private var lastIdbKey: String? = null
     private var lastFsPath: String? = null
 
-    @Composable
     actual fun getModelPath(modelFileName: String): String = modelFileName
 
     actual fun initEmbedModel(modelPath: String): Boolean = false

--- a/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/StableDiffusionBridge.wasmJs.kt
@@ -1,9 +1,6 @@
 package com.llamatik.library.platform
 
-import androidx.compose.runtime.Composable
-
 actual object StableDiffusionBridge {
-    @Composable
     actual fun getModelPath(modelFileName: String): String = "/models/$modelFileName"
     actual fun initModel(modelPath: String, threads: Int): Boolean = false
     actual fun txt2img(


### PR DESCRIPTION
We have removed the Compose dependency since it's not useful to have it in the library and adds a not needed dependency that could break implementations on other platforms different from android.