### PR TITLE
Make build in Windows stable

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -34,7 +34,9 @@ val desktopPlatform: String = when {
     else -> "linux"
 }
 
-val nativeLibDir = project(":library").layout.buildDirectory.dir("llama-jni/$desktopPlatform")
+val libraryNativeResourcesDir = project(":library")
+    .layout.buildDirectory
+    .dir("generated/native-resources/native/$desktopPlatform")
 val generatedNativeResources = layout.buildDirectory.dir("generated/nativeResources")
 
 kotlin {
@@ -343,7 +345,7 @@ tasks.withType(org.gradle.api.tasks.JavaExec::class.java).configureEach {
     }
 }
 
-// Copy the platform-native JNI library into build/generated/nativeResources/native/<platform>/
+// Copy the platform-native JNI library and manifest into build/generated/nativeResources/native/<platform>/
 val nativeLibPattern = when (desktopPlatform) {
     "macos" -> "*.dylib"
     "linux" -> "*.so"
@@ -351,9 +353,9 @@ val nativeLibPattern = when (desktopPlatform) {
 }
 
 val copyDesktopNativeLib by tasks.registering(Copy::class) {
-    dependsOn(":library:compileLlamaJniDesktop")
-    from(nativeLibDir)
-    include(nativeLibPattern)
+    dependsOn(":library:copyDesktopJniToResources")
+    from(libraryNativeResourcesDir)
+    include(nativeLibPattern, "native-libs.txt")
     into(generatedNativeResources.map { it.dir("native/$desktopPlatform") })
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -405,6 +405,9 @@ kotlin {
                 )
             }
 
+            if (desktopJniBuildDir.exists()) {
+                desktopJniBuildDir.deleteRecursively()
+            }
             desktopJniBuildDir.mkdirs()
 
             val args = mutableListOf(
@@ -417,12 +420,6 @@ kotlin {
 
             if (desktopPlatform == "macos") {
                 args += listOf("-DCMAKE_SYSTEM_NAME=Darwin")
-            }
-
-            if (desktopPlatform == "windows") {
-                // Use Ninja on Windows CI for faster, more reliable builds than Visual Studio generator.
-                // Ninja is pre-installed on GitHub windows-latest runners.
-                args += listOf("-G", "Ninja")
             }
 
             commandLine(args)
@@ -450,27 +447,38 @@ kotlin {
         dependsOn(compileLlamaJniDesktop)
 
         val outDir = generatedNativeResourcesDir.resolve("native/$desktopPlatform")
-
-        from(desktopJniBuildDir) {
-            when (desktopPlatform) {
-                "macos" -> include("*.dylib")
-                "linux" -> include("*.so", "*.so.*")
-                "windows" -> include("*.dll")
-            }
+        val nativeMatches = when (desktopPlatform) {
+            "macos" -> listOf("**/*.dylib")
+            "linux" -> listOf("**/*.so", "**/*.so.*")
+            "windows" -> listOf("**/*.dll")
+            else -> emptyList()
         }
+
+        from(fileTree(desktopJniBuildDir) {
+            include(nativeMatches)
+        })
+        eachFile {
+            path = name
+        }
+        includeEmptyDirs = false
         into(outDir)
 
         outputs.dir(outDir)
 
         doFirst {
-            val f = desktopJniBuildDir.resolve(libFileName)
-            if (!f.exists()) throw GradleException("Desktop JNI output not found: ${f.absolutePath}")
+            outDir.deleteRecursively()
+            outDir.mkdirs()
+
+            val f = fileTree(desktopJniBuildDir) {
+                include("**/$libFileName")
+            }.files.singleOrNull()
+            if (f == null) throw GradleException("Desktop JNI output not found under: ${desktopJniBuildDir.absolutePath}")
         }
 
         doLast {
             val copiedLibs = outDir
                 .listFiles()
-                ?.filter { it.isFile }
+                ?.filter { it.isFile && it.name != "native-libs.txt" }
                 ?.map { it.name }
                 ?.sorted()
                 .orEmpty()

--- a/library/cmake/llama-jni-desktop/CMakeLists.txt
+++ b/library/cmake/llama-jni-desktop/CMakeLists.txt
@@ -54,6 +54,14 @@ set(GGML_OPENMP OFF CACHE BOOL "" FORCE)
 
 add_subdirectory("${LLAMA_CPP_DIR}" "${CMAKE_BINARY_DIR}/llama-wrapper-build")
 
+if(WIN32 AND TARGET ggml-base)
+    # whisper.cpp applies this workaround when it owns ggml, but in our combined
+    # desktop build ggml comes from llama.cpp first so the whisper-side branch is skipped.
+    # Keep the Windows fix on the shared ggml-base target used by Java/JNI bindings.
+    target_compile_definitions(ggml-base PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    message(STATUS "Applied Windows ggml mutex constructor workaround to target: ggml-base")
+endif()
+
 set(HAVE_WHISPER OFF)
 if(EXISTS "${WHISPER_CPP_DIR}/CMakeLists.txt")
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
@@ -6,9 +6,14 @@ import kotlin.io.path.Path
 
 actual object WhisperBridge {
     init {
-        // Your project already loads native for LlamaBridge on JVM via System.load(...)
-        // If you already have a loader util, reuse it. Otherwise:
-        loadNativeFromResources()
+        val os = System.getProperty("os.name").lowercase()
+        if (os.contains("win")) {
+            // On Windows, re-loading the same DLL from another temp path fails after
+            // LlamaBridge has already loaded it. Reuse LlamaBridge's initialization instead.
+            LlamaBridge
+        } else {
+            loadNativeFromResources()
+        }
     }
 
     actual fun getModelPath(modelFileName: String): String {


### PR DESCRIPTION
Changes made to resolve issue #113:                                                                                                                                              
                                                                                                                                                                                   
  1. library/cmake/llama-jni-desktop/CMakeLists.txt                                                                                                                                
  Added _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR on ggml-base after the llama.cpp subdirectory is added. On Windows, MSVC generates a constexpr mutex constructor that crashes at runtime when ggml is initialized via llama.cpp before whisper.cpp can apply its own workaround. Scoped to WIN32 AND TARGET ggml-base so it's a no-op on macOS/Linux.             
                                                                                                                                                                                   
  2. library/src/jvmMain/.../WhisperBridge.jvm.kt                                                                                                                                  
  On Windows, instead of calling loadNativeFromResources() (which would try to load llama_jni.dll from a second temp path — causing UnsatisfiedLinkError since it was already loaded by LlamaBridge), the init block now simply references LlamaBridge to trigger its initialization. Behavior on macOS/Linux is unchanged.                                    
                                                                                                                                                                                 
  3. library/build.gradle.kts — buildLlamaJniDesktop task                                                                                                                          
  Removed the forced -G Ninja on Windows. The Ninja generator was causing MSVC toolchain resolution issues in non-CI environments. The build directory is now cleaned before CMake configure to avoid stale cache issues.                                                                                                                                           
                                                                                                                                                                                 
  4. library/build.gradle.kts — copyDesktopJniToResources task                                                                                                                     
  Changed the file copy to use a recursive fileTree with **/*.dll glob (instead of flat *.dll) so DLLs under Release/ subdirectories (produced by the Visual Studio generator) are found. Added eachFile { path = name } to flatten all matches into the output dir. Output dir is cleaned before each copy, and native-libs.txt is excluded from the library list it writes.                                                                                                                                                                     
                                                                                                                                                                                   
  5. composeApp/build.gradle.kts — copyDesktopNativeLib task                                                                                                                       
  Changed to depend on :library:copyDesktopJniToResources and copy from the library's generated resources dir (which already has the DLLs flattened and native-libs.txt generated), instead of copying directly from the raw CMake build output. This ensures native-libs.txt is also available in the composeApp's JVM resources.                                  
                                                                         