### PR TITLE
Solved generateContinue() issue

### DIFF
--- a/library/src/commonMain/cpp/llama_jni.cpp
+++ b/library/src/commonMain/cpp/llama_jni.cpp
@@ -950,6 +950,7 @@ static void stream_from_prompt(
     // Reset cancel flag at the start of each stream
     g_cancel_requested.store(false, std::memory_order_relaxed);
     llama_memory_clear(llama_get_memory(gen_ctx), false);
+    session_clear_state();
 
     std::vector<llama_token> tokens(2048);
     int n_tokens = tokenize_with_retry(llama_model_get_vocab(gen_model),
@@ -970,6 +971,8 @@ static void stream_from_prompt(
         env->CallVoidMethod(jCallback, m.onError, env->NewStringUTF("llama_decode failed on prompt"));
         return;
     }
+    g_session_tokens = tokens;
+    g_n_past = (int)tokens.size();
 
     float temperature    = g_temperature.load();
     float top_p          = g_top_p.load();
@@ -1010,6 +1013,8 @@ static void stream_from_prompt(
             jstring delta = env->NewStringUTF(piece_buf);
             if (delta) { env->CallVoidMethod(jCallback, m.onDelta, delta); env->DeleteLocalRef(delta); }
         }
+        g_session_tokens.push_back(tok);
+        ++g_n_past;
         return true;
     };
 


### PR DESCRIPTION
Related to issue #141

Root cause: stream_from_prompt in llama_jni.cpp never updated the global session tracking state (g_session_tokens, g_n_past). After generateStream()
  completed, those variables remained empty/zero. So when sessionSave() was called, it passed an empty token list to llama_state_save_file. When later
  sessionLoad() read the file back, n_loaded = 0, leaving g_n_past = 0 and g_session_tokens empty — causing session_is_active() to return false and
  generateContinue to fail.
  
  Fix (3 changes to stream_from_prompt in llama_jni.cpp):

  1. Line 953 — session_clear_state() after llama_memory_clear: explicitly resets session tracking when a new stream starts (KV cache is wiped anyway, so state
  must match)
  2. Lines 974–975 — After successful prompt decode: records the prompt tokens in g_session_tokens and sets g_n_past, so the save captures the full prompt
  context
  3. Lines 1016–1017 — Inside emit_token lambda: appends each generated token to g_session_tokens and increments g_n_past, keeping session state current
  throughout generation

  This mirrors exactly what iOS's llama_generate_stream already does via session_record_prompt_tokens_fresh + session_append_generated_token. After this fix,
  the call sequence generateStream() → sessionSave() → sessionLoad() → generateContinue() will work correctly.