### PR TITLE
Added Gemma4 multimodal Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ dependencyResolutionManagement {
 }
 
 commonMain.dependencies {
-    implementation("com.llamatik:library:1.5.0")
+    implementation("com.llamatik:library:1.7.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ only configuration.
 
 ## 📦 Current Versions
 
-- llama.cpp version: [b9208](https://github.com/ggml-org/llama.cpp/releases/tag/b9208)
+- llama.cpp version: [b9371](https://github.com/ggml-org/llama.cpp/releases/tag/b9371)
 - whisper.cpp version [v1.8.4](https://github.com/ggml-org/whisper.cpp/releases/tag/v1.8.4)
 - stablediffusion.cpp version [master-596-90e87bc](https://github.com/leejet/stable-diffusion.cpp/releases/tag/master-596-90e87bc)
 

--- a/library/cmake/llama-jni-desktop/CMakeLists.txt
+++ b/library/cmake/llama-jni-desktop/CMakeLists.txt
@@ -163,7 +163,7 @@ add_library(mtmd_sources OBJECT
     "${MTMD_DIR}/models/gemma4v.cpp"
     "${MTMD_DIR}/models/glm4v.cpp"
     "${MTMD_DIR}/models/granite-speech.cpp"
-    "${MTMD_DIR}/models/hunyuanocr.cpp"
+    "${MTMD_DIR}/models/hunyuanvl.cpp"
     "${MTMD_DIR}/models/internvl.cpp"
     "${MTMD_DIR}/models/kimik25.cpp"
     "${MTMD_DIR}/models/kimivl.cpp"

--- a/library/cmake/llama-wrapper/CMakeLists.txt
+++ b/library/cmake/llama-wrapper/CMakeLists.txt
@@ -204,7 +204,7 @@ add_library(mtmd_ios_obj OBJECT
         ${MTMD_DIR}/models/gemma4v.cpp
         ${MTMD_DIR}/models/glm4v.cpp
         ${MTMD_DIR}/models/granite-speech.cpp
-        ${MTMD_DIR}/models/hunyuanocr.cpp
+        ${MTMD_DIR}/models/hunyuanvl.cpp
         ${MTMD_DIR}/models/internvl.cpp
         ${MTMD_DIR}/models/kimik25.cpp
         ${MTMD_DIR}/models/kimivl.cpp

--- a/library/cmake/llamatik-wasm/CMakeLists.txt
+++ b/library/cmake/llamatik-wasm/CMakeLists.txt
@@ -73,7 +73,7 @@ if(EXISTS "${MTMD_DIR}/mtmd.cpp")
     "${MTMD_DIR}/models/gemma4v.cpp"
     "${MTMD_DIR}/models/glm4v.cpp"
     "${MTMD_DIR}/models/granite-speech.cpp"
-    "${MTMD_DIR}/models/hunyuanocr.cpp"
+    "${MTMD_DIR}/models/hunyuanvl.cpp"
     "${MTMD_DIR}/models/internvl.cpp"
     "${MTMD_DIR}/models/kimik25.cpp"
     "${MTMD_DIR}/models/kimivl.cpp"

--- a/library/src/commonMain/cpp/CMakeLists.txt
+++ b/library/src/commonMain/cpp/CMakeLists.txt
@@ -70,7 +70,7 @@ add_library(mtmd_sources OBJECT
         ${MTMD_DIR}/models/gemma4v.cpp
         ${MTMD_DIR}/models/glm4v.cpp
         ${MTMD_DIR}/models/granite-speech.cpp
-        ${MTMD_DIR}/models/hunyuanocr.cpp
+        ${MTMD_DIR}/models/hunyuanvl.cpp
         ${MTMD_DIR}/models/internvl.cpp
         ${MTMD_DIR}/models/kimik25.cpp
         ${MTMD_DIR}/models/kimivl.cpp

--- a/library/src/commonMain/cpp/llama_jni.cpp
+++ b/library/src/commonMain/cpp/llama_jni.cpp
@@ -272,11 +272,12 @@ static void drop_lines_with_prefix(std::string &s, const char *prefix_lc) {
 static std::string sanitize_generation(std::string s) {
     if (s.empty()) return s;
 
-    for (const char *stop: {"<end_of_turn>", "<|eot_id|>", "</s>"}) {
+    for (const char *stop: {"<end_of_turn>", "<|eot_id|>", "</s>", "<turn|>"}) {
         size_t p = s.find(stop);
         if (p != std::string::npos) { s = s.substr(0, p); }
     }
     drop_lines_with_prefix(s, "<start_of_turn>");
+    drop_lines_with_prefix(s, "<|turn>");
     drop_lines_with_prefix(s, "<|start_header_id|>");
     drop_lines_with_prefix(s, "<|end_header_id|>");
 
@@ -751,7 +752,7 @@ static std::string generate_with_optional_grammar(const char *prompt, const char
         int sn = llama_token_to_piece(vocab, tok, sp, (int) sizeof(sp), 0, /*special*/ 1);
         if (sn > 0) {
             sp[std::min(sn, (int) sizeof(sp) - 1)] = '\0';
-            if (std::strcmp(sp, "<end_of_turn>") == 0 || std::strcmp(sp, "<|eot_id|>") == 0 || std::strcmp(sp, "<start_of_turn>") == 0) {
+            if (std::strcmp(sp, "<end_of_turn>") == 0 || std::strcmp(sp, "<|eot_id|>") == 0 || std::strcmp(sp, "<start_of_turn>") == 0 || std::strcmp(sp, "<turn|>") == 0 || std::strcmp(sp, "<|turn>") == 0) {
                 break;
             }
         }
@@ -930,7 +931,8 @@ static bool resolve_stream_methods(JNIEnv *env, jobject cb, StreamMethods &m) {
 }
 
 static inline bool is_eot_piece(const char *s) {
-    return std::strcmp(s, "<end_of_turn>") == 0 || std::strcmp(s, "<|eot_id|>") == 0;
+    return std::strcmp(s, "<end_of_turn>") == 0 || std::strcmp(s, "<|eot_id|>") == 0
+        || std::strcmp(s, "<turn|>") == 0;
 }
 
 // Streams tokens from a prepared prompt string.
@@ -1005,7 +1007,7 @@ static void stream_from_prompt(
         int sn = llama_token_to_piece(vocab, tok, spec_buf, (int)sizeof(spec_buf), 0, 1);
         if (sn > 0) {
             spec_buf[std::min(sn, (int)sizeof(spec_buf)-1)] = '\0';
-            if (is_eot_piece(spec_buf) || std::strcmp(spec_buf, "<start_of_turn>") == 0) return false;
+            if (is_eot_piece(spec_buf) || std::strcmp(spec_buf, "<start_of_turn>") == 0 || std::strcmp(spec_buf, "<|turn>") == 0) return false;
         }
         int nn = llama_token_to_piece(vocab, tok, piece_buf, (int)sizeof(piece_buf), 0, 0);
         if (nn > 0) {
@@ -1668,7 +1670,7 @@ Java_com_llamatik_library_platform_LlamaBridge_nativeSessionStream(
         int sn = llama_token_to_piece(vocab, tok, spec_buf, (int)sizeof(spec_buf), 0, 1);
         if (sn > 0) {
             spec_buf[std::min(sn, (int)sizeof(spec_buf) - 1)] = '\0';
-            if (is_eot_piece(spec_buf) || std::strcmp(spec_buf, "<start_of_turn>") == 0) break;
+            if (is_eot_piece(spec_buf) || std::strcmp(spec_buf, "<start_of_turn>") == 0 || std::strcmp(spec_buf, "<|turn>") == 0) break;
         }
 
         llama_sampler_accept(sampler, tok);
@@ -1739,6 +1741,28 @@ Java_com_llamatik_library_platform_LlamaBridge_getModelFinetuneType(
     return env->NewStringUTF(buf);
 }
 
+// Fallback formatter for Gemma 4 — used when llama_chat_apply_template returns -1
+// because llama.cpp doesn't recognise the <|turn>/<turn|> template yet.
+static bool is_gemma4_template(const char *tmpl) {
+    if (!tmpl) return false;
+    return std::strstr(tmpl, "<|turn>") != nullptr && std::strstr(tmpl, "<turn|>") != nullptr;
+}
+
+static std::string apply_gemma4_template(
+        const std::vector<llama_chat_message> &chat,
+        bool add_ass) {
+    std::string out;
+    for (const auto &msg : chat) {
+        std::string role = msg.role;
+        if (role == "assistant") role = "model";
+        out += "<|turn>" + role + "\n";
+        out += trim(std::string(msg.content));
+        out += "<turn|>\n";
+    }
+    if (add_ass) out += "<|turn>model\n";
+    return out;
+}
+
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_com_llamatik_library_platform_LlamaBridge_nativeApplyChatTemplate(
@@ -1786,6 +1810,9 @@ Java_com_llamatik_library_platform_LlamaBridge_nativeApplyChatTemplate(
                 tmpl_cstr, chat.data(), (size_t) n,
                 (bool) addAssistantPrefix,
                 buf.data(), needed);
+        result = env->NewStringUTF(buf.c_str());
+    } else if (is_gemma4_template(tmpl_cstr)) {
+        std::string buf = apply_gemma4_template(chat, (bool) addAssistantPrefix);
         result = env->NewStringUTF(buf.c_str());
     }
 

--- a/library/src/iosMain/cpp/llama_embed.cpp
+++ b/library/src/iosMain/cpp/llama_embed.cpp
@@ -398,7 +398,9 @@ static bool looks_like_chat_formatted_prompt(const std::string &prompt) {
     const std::string low = lower_ascii(prompt);
 
     return low.find("<start_of_turn>") != std::string::npos ||
-            low.find("<end_of_turn>")   != std::string::npos ||
+            low.find("<end_of_turn>")       != std::string::npos ||
+            low.find("<|turn>")             != std::string::npos ||
+            low.find("<turn|>")             != std::string::npos ||
             low.find("<|start_header_id|>") != std::string::npos ||
             low.find("<|end_header_id|>")   != std::string::npos ||
             low.find("<|eot_id|>")          != std::string::npos ||
@@ -517,7 +519,7 @@ static void drop_lines_containing_ci(std::string &s, const char *needle_ci) {
 static std::string sanitize_generation_ios(std::string s) {
     if (s.empty()) return s;
 
-    for (const char* stop : { "<end_of_turn>", "<|eot_id|>", "</s>", "<start_of_turn>" }) {
+    for (const char* stop : { "<end_of_turn>", "<|eot_id|>", "</s>", "<start_of_turn>", "<turn|>", "<|turn>" }) {
         size_t p = s.find(stop);
         if (p != std::string::npos) {
             s = s.substr(0, p);
@@ -893,7 +895,9 @@ char *llama_generate(const char *prompt) {
             if (std::strcmp(piece, "<|eot_id|>") == 0 ||
                     std::strcmp(piece, "<end_of_turn>") == 0 ||
                     std::strcmp(piece, "</s>") == 0 ||
-                    std::strcmp(piece, "<start_of_turn>") == 0) {
+                    std::strcmp(piece, "<start_of_turn>") == 0 ||
+                    std::strcmp(piece, "<turn|>") == 0 ||
+                    std::strcmp(piece, "<|turn>") == 0) {
                 DBG("generate: hit EOT piece: %s", piece);
                 break;
             }
@@ -1183,7 +1187,8 @@ void llama_generate_stream(const char *prompt,
             if (nn >= (int)sizeof(spiece)) spiece[sizeof(spiece)-1] = '\0';
             else spiece[nn] = '\0';
             if (std::strcmp(spiece, "<|eot_id|>") == 0 || std::strcmp(spiece, "<end_of_turn>") == 0 ||
-                std::strcmp(spiece, "</s>") == 0 || std::strcmp(spiece, "<start_of_turn>") == 0)
+                std::strcmp(spiece, "</s>") == 0 || std::strcmp(spiece, "<start_of_turn>") == 0 ||
+                std::strcmp(spiece, "<turn|>") == 0 || std::strcmp(spiece, "<|turn>") == 0)
                 return false;
         }
         session_append_generated_token(tok);
@@ -1633,7 +1638,9 @@ char *llama_generate_continue(const char *prompt) {
             if (std::strcmp(sp, "<|eot_id|>") == 0 ||
                     std::strcmp(sp, "<end_of_turn>") == 0 ||
                     std::strcmp(sp, "<start_of_turn>") == 0 ||
-                    std::strcmp(sp, "</s>") == 0) {
+                    std::strcmp(sp, "</s>") == 0 ||
+                    std::strcmp(sp, "<turn|>") == 0 ||
+                    std::strcmp(sp, "<|turn>") == 0) {
                 break;
             }
         }
@@ -1778,6 +1785,28 @@ const char *llama_get_model_chat_template(void) {
     return llama_model_chat_template(gen_model, nullptr);
 }
 
+// Fallback formatter for Gemma 4 — used when llama_chat_apply_template returns -1
+// because llama.cpp doesn't recognise the <|turn>/<turn|> template yet.
+static bool is_gemma4_template(const char *tmpl) {
+    if (!tmpl) return false;
+    return std::strstr(tmpl, "<|turn>") != nullptr && std::strstr(tmpl, "<turn|>") != nullptr;
+}
+
+static std::string apply_gemma4_template_ios(
+        const std::vector<llama_chat_message> &chat,
+        bool add_ass) {
+    std::string out;
+    for (const auto &msg : chat) {
+        std::string role = msg.role;
+        if (role == "assistant") role = "model";
+        out += "<|turn>" + role + "\n";
+        out += trim_ios(std::string(msg.content));
+        out += "<turn|>\n";
+    }
+    if (add_ass) out += "<|turn>model\n";
+    return out;
+}
+
 char *llama_apply_chat_template(
         const char **roles,
         const char **contents,
@@ -1794,7 +1823,14 @@ char *llama_apply_chat_template(
 
     int32_t needed = llama_chat_apply_template(tmpl, chat.data(), chat.size(),
                                                add_assistant_prefix, nullptr, -1);
-    if (needed < 0) return nullptr;
+    if (needed < 0) {
+        if (!is_gemma4_template(tmpl)) return nullptr;
+        std::string formatted = apply_gemma4_template_ios(chat, add_assistant_prefix);
+        char *buf = (char *) std::malloc(formatted.size() + 1);
+        if (!buf) return nullptr;
+        std::memcpy(buf, formatted.c_str(), formatted.size() + 1);
+        return buf;
+    }
 
     char *buf = (char *) std::malloc((size_t)needed + 1);
     if (!buf) return nullptr;
@@ -1945,7 +1981,9 @@ void llama_session_stream(int64_t handle,
             if (std::strcmp(spiece, "<|eot_id|>") == 0 ||
                     std::strcmp(spiece, "<end_of_turn>") == 0 ||
                     std::strcmp(spiece, "</s>") == 0 ||
-                    std::strcmp(spiece, "<start_of_turn>") == 0) break;
+                    std::strcmp(spiece, "<start_of_turn>") == 0 ||
+                    std::strcmp(spiece, "<turn|>") == 0 ||
+                    std::strcmp(spiece, "<|turn>") == 0) break;
         }
 
         llama_sampler_accept(sampler, tok);


### PR DESCRIPTION
Solves the issue #142 

Here's what the fix covers:

  The reported problem: applyChatTemplate returns null for Gemma 4 E4B but works for Gemma 3 and Qwen2.5.

  Root cause: Gemma 4 uses a completely different template format — <|turn> / <turn|> instead of <start_of_turn> / <end_of_turn>. The llama.cpp version bundled
  at b9371 doesn't recognize this format in its heuristic detector, so llama_chat_apply_template returns -1, which the bridge translated directly to null.

  What our fix does:

  1. Detects Gemma 4 by scanning the GGUF's embedded Jinja template for <|turn> and <turn|> markers
  2. Falls back to our own formatter when llama.cpp returns -1 and the template is recognized as Gemma 4 — producing correctly formatted output like:
  <|turn>user
  Hello<turn|>
  <|turn>model
  3. Handles EOT tokens — <turn|> and <|turn> are now recognized as stop tokens so generation terminates cleanly for Gemma 4

  The fix applies to Android, JVM/Desktop, and iOS. The b9371 submodule bump also confirms that Gemma 4 inference itself (LLM_ARCH_GEMMA4, gemma4.cpp) is
  supported by the bundled llama.cpp version — so loading and running the model works, it was only the chat template formatting that was broken.

