### PR TITLE
Solved issue with Whisper Bridge

### DIFF
--- a/library/src/commonMain/cpp/whisper_jni.cpp
+++ b/library/src/commonMain/cpp/whisper_jni.cpp
@@ -1,6 +1,92 @@
 #include <jni.h>
+#include <cstring>
 #include <string>
 #include "whisper_stt.h"
+
+// Converts a raw C string from whisper.cpp to a valid Modified UTF-8 string
+// suitable for NewStringUTF(). Invalid byte sequences become U+FFFD; 4-byte
+// UTF-8 sequences are re-encoded as CESU-8 surrogate pairs; embedded NUL bytes
+// become the Modified UTF-8 two-byte NUL encoding (\xc0\x80).
+static std::string sanitize_for_modified_utf8(const char* src) {
+    std::string out;
+    if (!src) return out;
+    out.reserve(std::strlen(src));
+
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(src);
+    while (*p) {
+        const unsigned char c = *p;
+
+        if (c == 0x00) {
+            // Embedded NUL → Modified UTF-8 two-byte NUL
+            out += '\xc0';
+            out += '\x80';
+            ++p;
+        } else if (c < 0x80) {
+            // ASCII
+            out += static_cast<char>(c);
+            ++p;
+        } else if ((c & 0xE0) == 0xC0) {
+            // 2-byte sequence
+            if ((p[1] & 0xC0) == 0x80) {
+                const uint32_t cp = ((c & 0x1Fu) << 6) | (p[1] & 0x3Fu);
+                if (cp >= 0x80) {
+                    out += static_cast<char>(c);
+                    out += static_cast<char>(p[1]);
+                } else {
+                    out += "\xef\xbf\xbd"; // U+FFFD (overlong)
+                }
+                p += 2;
+            } else {
+                out += "\xef\xbf\xbd";
+                ++p;
+            }
+        } else if ((c & 0xF0) == 0xE0) {
+            // 3-byte sequence
+            if ((p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80) {
+                const uint32_t cp = ((c & 0x0Fu) << 12) | ((p[1] & 0x3Fu) << 6) | (p[2] & 0x3Fu);
+                if (cp >= 0x800 && !(cp >= 0xD800 && cp <= 0xDFFF)) {
+                    out += static_cast<char>(c);
+                    out += static_cast<char>(p[1]);
+                    out += static_cast<char>(p[2]);
+                } else {
+                    out += "\xef\xbf\xbd"; // overlong or lone surrogate
+                }
+                p += 3;
+            } else {
+                out += "\xef\xbf\xbd";
+                ++p;
+            }
+        } else if ((c & 0xF8) == 0xF0) {
+            // 4-byte sequence — re-encode as CESU-8 surrogate pair (valid Modified UTF-8)
+            if ((p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80 && (p[3] & 0xC0) == 0x80) {
+                const uint32_t cp = ((c & 0x07u) << 18) | ((p[1] & 0x3Fu) << 12) |
+                                    ((p[2] & 0x3Fu) << 6)  |  (p[3] & 0x3Fu);
+                if (cp >= 0x10000 && cp <= 0x10FFFF) {
+                    const uint32_t v  = cp - 0x10000u;
+                    const uint32_t hi = 0xD800u + (v >> 10);
+                    const uint32_t lo = 0xDC00u + (v & 0x3FFu);
+                    out += static_cast<char>(0xE0 | (hi >> 12));
+                    out += static_cast<char>(0x80 | ((hi >> 6) & 0x3F));
+                    out += static_cast<char>(0x80 | (hi & 0x3F));
+                    out += static_cast<char>(0xE0 | (lo >> 12));
+                    out += static_cast<char>(0x80 | ((lo >> 6) & 0x3F));
+                    out += static_cast<char>(0x80 | (lo & 0x3F));
+                } else {
+                    out += "\xef\xbf\xbd";
+                }
+                p += 4;
+            } else {
+                out += "\xef\xbf\xbd";
+                ++p;
+            }
+        } else {
+            // Invalid start byte (continuation byte or 0xF8-0xFF)
+            out += "\xef\xbf\xbd";
+            ++p;
+        }
+    }
+    return out;
+}
 
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_llamatik_library_platform_WhisperBridge_initModel(JNIEnv* env, jobject, jstring path) {
@@ -22,7 +108,8 @@ Java_com_llamatik_library_platform_WhisperBridge_transcribeWav(JNIEnv* env, jobj
     if (lang) env->ReleaseStringUTFChars(lang, clang);
     env->ReleaseStringUTFChars(wavPath, cwav);
 
-    return env->NewStringUTF(out ? out : "");
+    std::string safe = sanitize_for_modified_utf8(out ? out : "");
+    return env->NewStringUTF(safe.c_str());
 }
 
 extern "C" JNIEXPORT void JNICALL


### PR DESCRIPTION
Fix for issue #154 — WhisperBridge.transcribeWav SIGABRT on invalid UTF-8
  
  Root cause: whisper_jni.cpp:25 passed the raw output of whisper_stt_transcribe_wav() directly to env->NewStringUTF(). The JNI spec requires Modified UTF-8, which differs from
  standard UTF-8 in two ways: 4-byte sequences are illegal (they must be CESU-8 surrogate pairs), and NUL bytes must be two-byte encoded (\xc0\x80). When whisper.cpp's decoder
  produces any invalid byte sequence, CheckJNI aborts the process before Kotlin can catch anything.

  Fix: Added sanitize_for_modified_utf8() in whisper_jni.cpp that walks the raw C string byte-by-byte and:
  - Passes valid 1-, 2-, and 3-byte UTF-8 sequences through unchanged
  - Re-encodes 4-byte UTF-8 sequences as CESU-8 surrogate pairs (the only way to represent supplementary characters in Modified UTF-8)
  - Encodes embedded NUL bytes as \xc0\x80
  - Replaces any invalid byte (truncated sequences, lone continuation bytes, lone surrogates, overlong encodings) with U+FFFD (\xef\xbf\xbd)
  
  The sanitized string is then passed to NewStringUTF(). Callers never need to change — the crash is eliminated at the JNI boundary.