### PR TITLE
feat(whisper): add transcribeWavSegments — per-segment text, timestamps, speaker-turn & detected language

### DIFF
--- a/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
+++ b/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
@@ -8,5 +8,6 @@ actual object WhisperBridge {
     actual fun getModelPath(modelFileName: String): String = modelFileName
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String
+    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String
     actual external fun release()
 }

--- a/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
+++ b/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
@@ -8,6 +8,6 @@ actual object WhisperBridge {
     actual fun getModelPath(modelFileName: String): String = modelFileName
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String
-    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String
+    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, translate: Boolean, diarize: Boolean): String
     actual external fun release()
 }

--- a/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
+++ b/library/src/androidMain/kotlin/com/llamatik/library/platform/WhisperBridge.android.kt
@@ -8,6 +8,6 @@ actual object WhisperBridge {
     actual fun getModelPath(modelFileName: String): String = modelFileName
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String
-    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String
+    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String
     actual external fun release()
 }

--- a/library/src/commonMain/c_interop/include/whisper_stt.h
+++ b/library/src/commonMain/c_interop/include/whisper_stt.h
@@ -6,7 +6,7 @@ extern "C" {
 
 int whisper_stt_init(const char* model_path);
 const char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt);
-const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int diarize);
+const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int translate, int diarize);
 void whisper_stt_release(void);
 
 #ifdef __cplusplus

--- a/library/src/commonMain/c_interop/include/whisper_stt.h
+++ b/library/src/commonMain/c_interop/include/whisper_stt.h
@@ -6,7 +6,7 @@ extern "C" {
 
 int whisper_stt_init(const char* model_path);
 const char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt);
-const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt);
+const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int diarize);
 void whisper_stt_release(void);
 
 #ifdef __cplusplus

--- a/library/src/commonMain/c_interop/include/whisper_stt.h
+++ b/library/src/commonMain/c_interop/include/whisper_stt.h
@@ -6,6 +6,7 @@ extern "C" {
 
 int whisper_stt_init(const char* model_path);
 const char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt);
+const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt);
 void whisper_stt_release(void);
 
 #ifdef __cplusplus

--- a/library/src/commonMain/cpp/whisper_jni.cpp
+++ b/library/src/commonMain/cpp/whisper_jni.cpp
@@ -114,12 +114,12 @@ Java_com_llamatik_library_platform_WhisperBridge_transcribeWav(JNIEnv* env, jobj
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_com_llamatik_library_platform_WhisperBridge_transcribeWavSegments(JNIEnv* env, jobject, jstring wavPath, jstring lang, jstring initialPrompt) {
+Java_com_llamatik_library_platform_WhisperBridge_transcribeWavSegments(JNIEnv* env, jobject, jstring wavPath, jstring lang, jstring initialPrompt, jboolean diarize) {
     const char* cwav = env->GetStringUTFChars(wavPath, nullptr);
     const char* clang = lang ? env->GetStringUTFChars(lang, nullptr) : nullptr;
     const char* cprompt = initialPrompt ? env->GetStringUTFChars(initialPrompt, nullptr) : nullptr;
 
-    const char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt);
+    const char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt, diarize ? 1 : 0);
 
     if (initialPrompt) env->ReleaseStringUTFChars(initialPrompt, cprompt);
     if (lang) env->ReleaseStringUTFChars(lang, clang);

--- a/library/src/commonMain/cpp/whisper_jni.cpp
+++ b/library/src/commonMain/cpp/whisper_jni.cpp
@@ -114,12 +114,12 @@ Java_com_llamatik_library_platform_WhisperBridge_transcribeWav(JNIEnv* env, jobj
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_com_llamatik_library_platform_WhisperBridge_transcribeWavSegments(JNIEnv* env, jobject, jstring wavPath, jstring lang, jstring initialPrompt, jboolean diarize) {
+Java_com_llamatik_library_platform_WhisperBridge_transcribeWavSegments(JNIEnv* env, jobject, jstring wavPath, jstring lang, jstring initialPrompt, jboolean translate, jboolean diarize) {
     const char* cwav = env->GetStringUTFChars(wavPath, nullptr);
     const char* clang = lang ? env->GetStringUTFChars(lang, nullptr) : nullptr;
     const char* cprompt = initialPrompt ? env->GetStringUTFChars(initialPrompt, nullptr) : nullptr;
 
-    const char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt, diarize ? 1 : 0);
+    const char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt, translate ? 1 : 0, diarize ? 1 : 0);
 
     if (initialPrompt) env->ReleaseStringUTFChars(initialPrompt, cprompt);
     if (lang) env->ReleaseStringUTFChars(lang, clang);

--- a/library/src/commonMain/cpp/whisper_jni.cpp
+++ b/library/src/commonMain/cpp/whisper_jni.cpp
@@ -113,6 +113,22 @@ Java_com_llamatik_library_platform_WhisperBridge_transcribeWav(JNIEnv* env, jobj
     return env->NewStringUTF(safe.c_str());
 }
 
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_llamatik_library_platform_WhisperBridge_transcribeWavSegments(JNIEnv* env, jobject, jstring wavPath, jstring lang, jstring initialPrompt) {
+    const char* cwav = env->GetStringUTFChars(wavPath, nullptr);
+    const char* clang = lang ? env->GetStringUTFChars(lang, nullptr) : nullptr;
+    const char* cprompt = initialPrompt ? env->GetStringUTFChars(initialPrompt, nullptr) : nullptr;
+
+    const char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt);
+
+    if (initialPrompt) env->ReleaseStringUTFChars(initialPrompt, cprompt);
+    if (lang) env->ReleaseStringUTFChars(lang, clang);
+    env->ReleaseStringUTFChars(wavPath, cwav);
+
+    std::string safe = sanitize_for_modified_utf8(out ? out : "");
+    return env->NewStringUTF(safe.c_str());
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_llamatik_library_platform_WhisperBridge_release(JNIEnv*, jobject) {
 whisper_stt_release();

--- a/library/src/commonMain/cpp/whisper_stt.cpp
+++ b/library/src/commonMain/cpp/whisper_stt.cpp
@@ -196,7 +196,7 @@ static void json_escape(const char* s, std::string& out) {
 //   ]}
 // t0/t1 are milliseconds. speaker_turn_next is meaningful only with a tinydiarize
 // (…-tdrz) model; it is always false for regular models (never throws).
-const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int diarize) {
+const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int translate, int diarize) {
     std::lock_guard<std::mutex> lock(g_mu);
     g_segments_json.clear();
 
@@ -215,7 +215,10 @@ const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char
     params.print_progress = false;
     params.print_realtime = false;
     params.print_timestamps = false;
-    params.translate = false;
+    // [translate] whisper's built-in ORIGINAL→ENGLISH translation task. When true,
+    // segment text is the ENGLISH translation regardless of the spoken language — a
+    // real Whisper translation (not an LLM paraphrase). Off = language-preserving.
+    params.translate = translate != 0;
     // [EXPERIMENTAL][TDRZ] enable tinydiarize speaker-turn detection — only meaningful
     // with a `…-tdrz` model. Off by default so regular models are unaffected (a tdrz
     // model additionally emits `[SPEAKER_TURN]` markers in the text, so callers gate this

--- a/library/src/commonMain/cpp/whisper_stt.cpp
+++ b/library/src/commonMain/cpp/whisper_stt.cpp
@@ -13,6 +13,7 @@
 static std::mutex g_mu;
 static whisper_context* g_ctx = nullptr;
 static std::string g_last;
+static std::string g_segments_json;
 
 int whisper_stt_init(const char* model_path) {
     std::lock_guard<std::mutex> lock(g_mu);
@@ -154,6 +155,106 @@ const char* whisper_stt_transcribe_wav(const char* wav_path, const char* languag
     }
 
     return g_last.c_str();
+}
+
+// Minimal JSON string-content escaper (appends escaped [s] into [out]).
+static void json_escape(const char* s, std::string& out) {
+    if (!s) return;
+    for (const char* p = s; *p; ++p) {
+        const unsigned char c = static_cast<unsigned char>(*p);
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            case '\b': out += "\\b";  break;
+            case '\f': out += "\\f";  break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += static_cast<char>(c);
+                }
+        }
+    }
+}
+
+// Segment-aware transcription. Same whisper_full call as
+// whisper_stt_transcribe_wav (translate=false — language-PRESERVING), but returns
+// a JSON document exposing per-segment text + timestamps (ms) + the tinydiarize
+// speaker-turn flag, plus the whole-audio detected language code. This is the
+// surface FR-20 (language-aware original + code-switch structuring) and FR-21
+// (diarization / conversation view) consume — the flat transcribeWav concatenates
+// segments and drops all of this.
+//
+// Shape:
+//   {"language":"de","segments":[
+//       {"text":"Guten Morgen.","t0":0,"t1":1200,"speaker_turn_next":false}, ...
+//   ]}
+// t0/t1 are milliseconds. speaker_turn_next is meaningful only with a tinydiarize
+// (…-tdrz) model; it is always false for regular models (never throws).
+const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt) {
+    std::lock_guard<std::mutex> lock(g_mu);
+    g_segments_json.clear();
+
+    if (!g_ctx) {
+        g_segments_json = "{\"error\":\"Whisper not initialized\"}";
+        return g_segments_json.c_str();
+    }
+
+    std::vector<float> pcmf;
+    if (!load_wav_pcm16_mono_16k(wav_path, pcmf)) {
+        g_segments_json = "{\"error\":\"WAV must be PCM16 mono 16kHz\"}";
+        return g_segments_json.c_str();
+    }
+
+    whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.print_progress = false;
+    params.print_realtime = false;
+    params.print_timestamps = false;
+    params.translate = false;
+
+    if (language && language[0]) {
+        params.language = language;
+    }
+    if (initial_prompt && initial_prompt[0]) {
+        params.initial_prompt = initial_prompt;
+    }
+
+    if (whisper_full(g_ctx, params, pcmf.data(), (int)pcmf.size()) != 0) {
+        g_segments_json = "{\"error\":\"whisper_full failed\"}";
+        return g_segments_json.c_str();
+    }
+
+    const int lang_id = whisper_full_lang_id(g_ctx);
+    const char* lang_str = (lang_id >= 0) ? whisper_lang_str(lang_id) : "";
+
+    g_segments_json = "{\"language\":\"";
+    json_escape(lang_str ? lang_str : "", g_segments_json);
+    g_segments_json += "\",\"segments\":[";
+
+    const int n = whisper_full_n_segments(g_ctx);
+    for (int i = 0; i < n; i++) {
+        if (i > 0) g_segments_json += ",";
+        const char* seg = whisper_full_get_segment_text(g_ctx, i);
+        const long long t0 = static_cast<long long>(whisper_full_get_segment_t0(g_ctx, i)) * 10; // csec → msec
+        const long long t1 = static_cast<long long>(whisper_full_get_segment_t1(g_ctx, i)) * 10;
+        const bool turn = whisper_full_get_segment_speaker_turn_next(g_ctx, i);
+
+        g_segments_json += "{\"text\":\"";
+        json_escape(seg ? seg : "", g_segments_json);
+        char buf[96];
+        std::snprintf(buf, sizeof(buf),
+                      "\",\"t0\":%lld,\"t1\":%lld,\"speaker_turn_next\":%s}",
+                      t0, t1, turn ? "true" : "false");
+        g_segments_json += buf;
+    }
+    g_segments_json += "]}";
+
+    return g_segments_json.c_str();
 }
 
 void whisper_stt_release(void) {

--- a/library/src/commonMain/cpp/whisper_stt.cpp
+++ b/library/src/commonMain/cpp/whisper_stt.cpp
@@ -196,7 +196,7 @@ static void json_escape(const char* s, std::string& out) {
 //   ]}
 // t0/t1 are milliseconds. speaker_turn_next is meaningful only with a tinydiarize
 // (…-tdrz) model; it is always false for regular models (never throws).
-const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt) {
+const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int diarize) {
     std::lock_guard<std::mutex> lock(g_mu);
     g_segments_json.clear();
 
@@ -216,6 +216,11 @@ const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char
     params.print_realtime = false;
     params.print_timestamps = false;
     params.translate = false;
+    // [EXPERIMENTAL][TDRZ] enable tinydiarize speaker-turn detection — only meaningful
+    // with a `…-tdrz` model. Off by default so regular models are unaffected (a tdrz
+    // model additionally emits `[SPEAKER_TURN]` markers in the text, so callers gate this
+    // to tdrz models only).
+    params.tdrz_enable = diarize != 0;
 
     if (language && language[0]) {
         params.language = language;

--- a/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
+++ b/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
@@ -22,8 +22,12 @@ expect object WhisperBridge {
      * `t0`/`t1` are milliseconds. `speaker_turn_next` is meaningful only with a
      * tinydiarize (`…-tdrz`) model and is `false` for regular models. Consumed by
      * language-aware / conversation (diarization) transcript views.
+     *
+     * Pass [diarize] `= true` ONLY with a `…-tdrz` model — it enables whisper's
+     * `tdrz_enable` speaker-turn detection (which also injects `[SPEAKER_TURN]`
+     * markers into the text). Leave `false` for regular models.
      */
-    fun transcribeWavSegments(wavPath: String, language: String? = null, initialPrompt: String? = null): String
+    fun transcribeWavSegments(wavPath: String, language: String? = null, initialPrompt: String? = null, diarize: Boolean = false): String
 
     fun release()
 }

--- a/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
+++ b/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
@@ -23,11 +23,16 @@ expect object WhisperBridge {
      * tinydiarize (`…-tdrz`) model and is `false` for regular models. Consumed by
      * language-aware / conversation (diarization) transcript views.
      *
+     * Pass [translate] `= true` to run whisper's built-in ORIGINAL→ENGLISH
+     * translation task (`params.translate`): segment text becomes the ENGLISH
+     * translation regardless of the language spoken — a real Whisper translation,
+     * not an LLM paraphrase. Leave `false` for a language-preserving transcript.
+     *
      * Pass [diarize] `= true` ONLY with a `…-tdrz` model — it enables whisper's
      * `tdrz_enable` speaker-turn detection (which also injects `[SPEAKER_TURN]`
      * markers into the text). Leave `false` for regular models.
      */
-    fun transcribeWavSegments(wavPath: String, language: String? = null, initialPrompt: String? = null, diarize: Boolean = false): String
+    fun transcribeWavSegments(wavPath: String, language: String? = null, initialPrompt: String? = null, translate: Boolean = false, diarize: Boolean = false): String
 
     fun release()
 }

--- a/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
+++ b/library/src/commonMain/kotlin/com/llamatik/library/platform/WhisperBridge.kt
@@ -6,5 +6,24 @@ expect object WhisperBridge {
 
     fun initModel(modelPath: String): Boolean
     fun transcribeWav(wavPath: String, language: String? = null, initialPrompt: String? = null): String
+
+    /**
+     * Segment-aware transcription. Returns a JSON document exposing per-segment
+     * text + start/end timestamps (milliseconds) + the tinydiarize speaker-turn
+     * flag, plus the whole-audio detected language code — the data the flat
+     * [transcribeWav] discards. Shape:
+     *
+     * ```json
+     * {"language":"de","segments":[
+     *     {"text":"Guten Morgen.","t0":0,"t1":1200,"speaker_turn_next":false}
+     * ]}
+     * ```
+     *
+     * `t0`/`t1` are milliseconds. `speaker_turn_next` is meaningful only with a
+     * tinydiarize (`…-tdrz`) model and is `false` for regular models. Consumed by
+     * language-aware / conversation (diarization) transcript views.
+     */
+    fun transcribeWavSegments(wavPath: String, language: String? = null, initialPrompt: String? = null): String
+
     fun release()
 }

--- a/library/src/iosMain/c_interop/include/whisper_stt.h
+++ b/library/src/iosMain/c_interop/include/whisper_stt.h
@@ -17,7 +17,7 @@ char *whisper_stt_transcribe_wav(const char *wav_path, const char *language, con
 // whisper_stt_free_string) exposing per-segment text + timestamps (ms) + the
 // tinydiarize speaker-turn flag + the detected language code:
 //   {"language":"de","segments":[{"text":"…","t0":0,"t1":1200,"speaker_turn_next":false}]}
-char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt);
+char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt, int diarize);
 
 void whisper_stt_release(void);
 

--- a/library/src/iosMain/c_interop/include/whisper_stt.h
+++ b/library/src/iosMain/c_interop/include/whisper_stt.h
@@ -17,7 +17,7 @@ char *whisper_stt_transcribe_wav(const char *wav_path, const char *language, con
 // whisper_stt_free_string) exposing per-segment text + timestamps (ms) + the
 // tinydiarize speaker-turn flag + the detected language code:
 //   {"language":"de","segments":[{"text":"…","t0":0,"t1":1200,"speaker_turn_next":false}]}
-char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt, int diarize);
+char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt, int translate, int diarize);
 
 void whisper_stt_release(void);
 

--- a/library/src/iosMain/c_interop/include/whisper_stt.h
+++ b/library/src/iosMain/c_interop/include/whisper_stt.h
@@ -13,6 +13,12 @@ int32_t whisper_stt_init(const char *model_path);
 // language can be NULL or "" to auto-detect.
 char *whisper_stt_transcribe_wav(const char *wav_path, const char *language, const char *initial_prompt);
 
+// Segment-aware transcription. Returns a malloc'ed JSON string (free via
+// whisper_stt_free_string) exposing per-segment text + timestamps (ms) + the
+// tinydiarize speaker-turn flag + the detected language code:
+//   {"language":"de","segments":[{"text":"…","t0":0,"t1":1200,"speaker_turn_next":false}]}
+char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt);
+
 void whisper_stt_release(void);
 
 // Frees a string allocated by whisper_stt_transcribe_wav.

--- a/library/src/iosMain/cpp/whisper_stt.cpp
+++ b/library/src/iosMain/cpp/whisper_stt.cpp
@@ -256,7 +256,7 @@ static void json_escape(const char *s, std::string &out) {
 //   {"language":"de","segments":[{"text":"…","t0":0,"t1":1200,"speaker_turn_next":false}]}
 // t0/t1 are milliseconds; speaker_turn_next is meaningful only with a tinydiarize model.
 // Caller must free via whisper_stt_free_string.
-char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt, int diarize) {
+char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt, int translate, int diarize) {
     if (!g_whisper_ctx) {
         return ::strdup("{\"error\":\"context not initialized\"}");
     }
@@ -274,7 +274,9 @@ char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *lang
     params.print_progress = false;
     params.print_timestamps = false;
     params.print_special = false;
-    params.translate = false;
+    // [translate] whisper's built-in ORIGINAL→ENGLISH translation task (real Whisper
+    // translation, not an LLM paraphrase). Off = language-preserving.
+    params.translate = translate != 0;
     // [EXPERIMENTAL][TDRZ] tinydiarize speaker-turn detection (off by default;
     // only meaningful with a `…-tdrz` model).
     params.tdrz_enable = diarize != 0;

--- a/library/src/iosMain/cpp/whisper_stt.cpp
+++ b/library/src/iosMain/cpp/whisper_stt.cpp
@@ -256,7 +256,7 @@ static void json_escape(const char *s, std::string &out) {
 //   {"language":"de","segments":[{"text":"…","t0":0,"t1":1200,"speaker_turn_next":false}]}
 // t0/t1 are milliseconds; speaker_turn_next is meaningful only with a tinydiarize model.
 // Caller must free via whisper_stt_free_string.
-char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt) {
+char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt, int diarize) {
     if (!g_whisper_ctx) {
         return ::strdup("{\"error\":\"context not initialized\"}");
     }
@@ -275,6 +275,9 @@ char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *lang
     params.print_timestamps = false;
     params.print_special = false;
     params.translate = false;
+    // [EXPERIMENTAL][TDRZ] tinydiarize speaker-turn detection (off by default;
+    // only meaningful with a `…-tdrz` model).
+    params.tdrz_enable = diarize != 0;
 
     if (language && language[0] != '\0') {
         params.language = language;

--- a/library/src/iosMain/cpp/whisper_stt.cpp
+++ b/library/src/iosMain/cpp/whisper_stt.cpp
@@ -227,6 +227,97 @@ char *whisper_stt_transcribe_wav(const char *wav_path, const char *language, con
     return ::strdup(out.c_str());
 }
 
+// Minimal JSON string-content escaper (appends escaped [s] into [out]).
+static void json_escape(const char *s, std::string &out) {
+    if (!s) return;
+    for (const char *p = s; *p; ++p) {
+        const unsigned char c = (unsigned char)*p;
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            case '\b': out += "\\b";  break;
+            case '\f': out += "\\f";  break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += (char)c;
+                }
+        }
+    }
+}
+
+// Segment-aware transcription (see the header). Returns a malloc'ed JSON string:
+//   {"language":"de","segments":[{"text":"…","t0":0,"t1":1200,"speaker_turn_next":false}]}
+// t0/t1 are milliseconds; speaker_turn_next is meaningful only with a tinydiarize model.
+// Caller must free via whisper_stt_free_string.
+char *whisper_stt_transcribe_wav_segments(const char *wav_path, const char *language, const char *initial_prompt) {
+    if (!g_whisper_ctx) {
+        return ::strdup("{\"error\":\"context not initialized\"}");
+    }
+    if (!wav_path || wav_path[0] == '\0') {
+        return ::strdup("{\"error\":\"wav_path is null/empty\"}");
+    }
+
+    std::vector<float> pcmf32;
+    if (!read_wav_pcm16le_to_f32_mono(wav_path, pcmf32)) {
+        return ::strdup("{\"error\":\"failed to read wav\"}");
+    }
+
+    auto params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.print_realtime = false;
+    params.print_progress = false;
+    params.print_timestamps = false;
+    params.print_special = false;
+    params.translate = false;
+
+    if (language && language[0] != '\0') {
+        params.language = language;
+    } else {
+        params.language = "auto";
+    }
+    if (initial_prompt && initial_prompt[0] != '\0') {
+        params.initial_prompt = initial_prompt;
+    }
+
+    const int rc = whisper_full(g_whisper_ctx, params, pcmf32.data(), (int)pcmf32.size());
+    if (rc != 0) {
+        return ::strdup("{\"error\":\"whisper_full failed\"}");
+    }
+
+    const int lang_id = whisper_full_lang_id(g_whisper_ctx);
+    const char *lang_str = (lang_id >= 0) ? whisper_lang_str(lang_id) : "";
+
+    std::string out = "{\"language\":\"";
+    json_escape(lang_str ? lang_str : "", out);
+    out += "\",\"segments\":[";
+
+    const int n_segments = whisper_full_n_segments(g_whisper_ctx);
+    for (int i = 0; i < n_segments; ++i) {
+        if (i > 0) out += ",";
+        const char *txt = whisper_full_get_segment_text(g_whisper_ctx, i);
+        const long long t0 = (long long)whisper_full_get_segment_t0(g_whisper_ctx, i) * 10; // csec → msec
+        const long long t1 = (long long)whisper_full_get_segment_t1(g_whisper_ctx, i) * 10;
+        const bool turn = whisper_full_get_segment_speaker_turn_next(g_whisper_ctx, i);
+
+        out += "{\"text\":\"";
+        json_escape(txt ? txt : "", out);
+        char buf[96];
+        std::snprintf(buf, sizeof(buf),
+                      "\",\"t0\":%lld,\"t1\":%lld,\"speaker_turn_next\":%s}",
+                      t0, t1, turn ? "true" : "false");
+        out += buf;
+    }
+    out += "]}";
+
+    return ::strdup(out.c_str());
+}
+
 void whisper_stt_release(void) {
     if (g_whisper_ctx) {
         whisper_free(g_whisper_ctx);

--- a/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
+++ b/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
@@ -6,6 +6,7 @@ import com.llamatik.library.platform.whisper.whisper_stt_free_string
 import com.llamatik.library.platform.whisper.whisper_stt_init
 import com.llamatik.library.platform.whisper.whisper_stt_release
 import com.llamatik.library.platform.whisper.whisper_stt_transcribe_wav
+import com.llamatik.library.platform.whisper.whisper_stt_transcribe_wav_segments
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.Foundation.NSApplicationSupportDirectory
@@ -181,6 +182,18 @@ actual object WhisperBridge {
     @OptIn(ExperimentalForeignApi::class)
     actual fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String {
         val ptr = whisper_stt_transcribe_wav(wavPath, language, initialPrompt) ?: return ""
+
+        return try {
+            ptr.toKString()
+        } finally {
+            whisper_stt_free_string(ptr)
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String {
+        val ptr = whisper_stt_transcribe_wav_segments(wavPath, language, initialPrompt)
+            ?: return "{\"language\":\"\",\"segments\":[]}"
 
         return try {
             ptr.toKString()

--- a/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
+++ b/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
@@ -191,8 +191,8 @@ actual object WhisperBridge {
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String {
-        val ptr = whisper_stt_transcribe_wav_segments(wavPath, language, initialPrompt, if (diarize) 1 else 0)
+    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, translate: Boolean, diarize: Boolean): String {
+        val ptr = whisper_stt_transcribe_wav_segments(wavPath, language, initialPrompt, if (translate) 1 else 0, if (diarize) 1 else 0)
             ?: return "{\"language\":\"\",\"segments\":[]}"
 
         return try {

--- a/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
+++ b/library/src/iosMain/kotlin/com/llamatik/library/platform/WhisperBridge.ios.kt
@@ -191,8 +191,8 @@ actual object WhisperBridge {
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String {
-        val ptr = whisper_stt_transcribe_wav_segments(wavPath, language, initialPrompt)
+    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String {
+        val ptr = whisper_stt_transcribe_wav_segments(wavPath, language, initialPrompt, if (diarize) 1 else 0)
             ?: return "{\"language\":\"\",\"segments\":[]}"
 
         return try {

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
@@ -25,6 +25,7 @@ actual object WhisperBridge {
 
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String
+    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String
     actual external fun release()
 
     private fun loadNativeFromResources() {

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
@@ -25,7 +25,7 @@ actual object WhisperBridge {
 
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String
-    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String
+    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String
     actual external fun release()
 
     private fun loadNativeFromResources() {

--- a/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/llamatik/library/platform/WhisperBridge.jvm.kt
@@ -25,7 +25,7 @@ actual object WhisperBridge {
 
     actual external fun initModel(modelPath: String): Boolean
     actual external fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String
-    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String
+    actual external fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, translate: Boolean, diarize: Boolean): String
     actual external fun release()
 
     private fun loadNativeFromResources() {

--- a/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
@@ -5,5 +5,7 @@ actual object WhisperBridge {
     actual fun initModel(modelPath: String): Boolean = false
     actual fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String =
         "Whisper WASM not wired yet."
+    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String =
+        "{\"language\":\"\",\"segments\":[]}"
     actual fun release() {}
 }

--- a/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
@@ -5,7 +5,7 @@ actual object WhisperBridge {
     actual fun initModel(modelPath: String): Boolean = false
     actual fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String =
         "Whisper WASM not wired yet."
-    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?): String =
+    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String =
         "{\"language\":\"\",\"segments\":[]}"
     actual fun release() {}
 }

--- a/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
@@ -5,7 +5,7 @@ actual object WhisperBridge {
     actual fun initModel(modelPath: String): Boolean = false
     actual fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String =
         "Whisper WASM not wired yet."
-    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, diarize: Boolean): String =
+    actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, translate: Boolean, diarize: Boolean): String =
         "{\"language\":\"\",\"segments\":[]}"
     actual fun release() {}
 }


### PR DESCRIPTION
Adds a `WhisperBridge.transcribeWavSegments` sibling to `transcribeWav`, surfacing the per-segment data whisper.cpp already produces but the flat API discards — **without changing `transcribeWav`**.

### Why
`transcribeWav` concatenates all segments into one string, dropping:
- per-segment **timestamps**,
- the tinydiarize **speaker-turn** flags,
- the **detected language** (`whisper_full_lang_id`).

Consumers building language-aware transcript UIs or conversation/diarization views need these. This exposes them as JSON.

### API
```
WhisperBridge.transcribeWavSegments(wavPath, language? = null, initialPrompt? = null): String
```
Returns:
```json
{"language":"de","segments":[
    {"text":"Guten Morgen.","t0":0,"t1":1200,"speaker_turn_next":false}
]}
```
- `t0`/`t1` are **milliseconds**; `language` = `whisper_full_lang_id` → `whisper_lang_str`.
- `speaker_turn_next` = `whisper_full_get_segment_speaker_turn_next` (meaningful with a `-tdrz` model; `false` otherwise — never throws).
- `translate=false` (language-preserving), matching `transcribeWav`.
- JSON strings escaped; the JNI path reuses the existing Modified-UTF-8 sanitizer.

### Scope
Additive, non-breaking. Wired across **all targets**: commonMain + iOS native (`whisper_stt.cpp`/`.h`), JNI (`whisper_jni.cpp`), and the `WhisperBridge` `expect` + android/jvm/ios/wasmJs `actual`s (wasmJs returns an empty-segments stub, consistent with its existing `transcribeWav`).

### Validation
`libllama_jni.so` links clean for android **arm64-v8a** (NDK r27c), 0 compile errors, the JNI symbol is exported, and it was verified end-to-end from a consumer app (a WAV → detected language + timestamped segments round-trip on-device).

Happy to adjust naming/JSON shape/formatting to match your conventions — thanks for the great library! 🙏