### PR TITLE
Corrected Whisper issues and applied improvements

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -2,3 +2,6 @@ paths-ignore:
   - llama.cpp
   - whisper.cpp
   - stable-diffusion.cpp
+  - "**/build/generated/**"
+  - "**/build/tmp/**"
+  - "**/.gradle/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,3 +65,6 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          ram: 4096
+          threads: 2

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Designed for **privacy-first**, **offline-capable**, and **cross-platform** AI a
 - ✅ 16kHz mono WAV support
 - ✅ Selectable Whisper models
 - ✅ Integrated model download + management
+- ✅ **Segment-aware transcription** — per-segment text, timestamps, detected language, and speaker-turn boundaries (`transcribeWavSegments`)
+- ✅ Optional **translation to English** (whisper's built-in translate task)
+- ✅ Optional **tinydiarize speaker-turn detection** (`…-tdrz` models)
 
 ### 🎨 Image Generation (stable-diffusion.cpp)
 
@@ -514,6 +517,30 @@ object WhisperBridge {
      */
     fun transcribeWav(wavPath: String, language: String? = null, initialPrompt: String? = null): String
 
+    /**
+     * Segment-aware transcription. Returns a JSON document with per-segment text,
+     * start/end timestamps (milliseconds), speaker-turn flag, and the detected
+     * language code. Shape:
+     *
+     * ```json
+     * {"language":"de","segments":[
+     *     {"text":"Guten Morgen.","t0":0,"t1":1200,"speaker_turn_next":false}
+     * ]}
+     * ```
+     *
+     * @param translate  `true` = translate audio to English (whisper's built-in
+     *                   translate task). Default `false` = language-preserving.
+     * @param diarize    `true` = enable tinydiarize speaker-turn detection. Only
+     *                   meaningful with a `…-tdrz` model; leave `false` otherwise.
+     */
+    fun transcribeWavSegments(
+        wavPath: String,
+        language: String? = null,
+        initialPrompt: String? = null,
+        translate: Boolean = false,
+        diarize: Boolean = false,
+    ): String
+
     /** Frees native resources. */
     fun release()
 }
@@ -541,6 +568,51 @@ WhisperBridge.release()
 ```
 
 **Note**: WhisperBridge expects a WAV file path. Llamatik’s app uses AudioRecorder + AudioPaths.tempWavPath() to generate the WAV before calling transcribeWav(...).
+
+#### Segment-aware transcription
+
+`transcribeWavSegments` returns a JSON document that exposes everything `transcribeWav` discards — per-segment timestamps, the auto-detected language, and (with a `-tdrz` model) speaker-turn boundaries.
+
+```kotlin
+import com.llamatik.library.platform.WhisperBridge
+import kotlinx.serialization.json.*
+
+WhisperBridge.initModel(modelPath)
+
+val json = WhisperBridge.transcribeWavSegments(
+    wavPath  = "/path/to/recording.wav",
+    language = null,           // auto-detect
+)
+// {"language":"de","segments":[{"text":"Guten Morgen.","t0":0,"t1":1200,"speaker_turn_next":false},...]}
+
+// Parse with kotlinx.serialization or any JSON library
+val root     = Json.parseToJsonElement(json).jsonObject
+val language = root["language"]?.jsonPrimitive?.content
+val segments = root["segments"]!!.jsonArray
+for (seg in segments) {
+    val obj   = seg.jsonObject
+    val text  = obj["text"]?.jsonPrimitive?.content
+    val t0Ms  = obj["t0"]?.jsonPrimitive?.long   // start in milliseconds
+    val t1Ms  = obj["t1"]?.jsonPrimitive?.long   // end in milliseconds
+    val turn  = obj["speaker_turn_next"]?.jsonPrimitive?.boolean
+    println("[$t0Ms–$t1Ms ms] $text  (speaker_turn=$turn)")
+}
+```
+
+**Translate to English** — pass `translate = true` to get the English translation of the audio regardless of the spoken language:
+
+```kotlin
+val json = WhisperBridge.transcribeWavSegments(wavPath, translate = true)
+```
+
+**Speaker diarization** — pass `diarize = true` **only** with a tinydiarize (`…-tdrz`) model to get real `speaker_turn_next` boundaries:
+
+```kotlin
+val json = WhisperBridge.transcribeWavSegments(
+    wavPath = wavPath,
+    diarize = true,   // requires a …-tdrz model (e.g. small.en-tdrz)
+)
+```
 
 
 ### 🎨 Image Generation (StableDiffusionBridge)

--- a/library/src/commonMain/c_interop/include/whisper_stt.h
+++ b/library/src/commonMain/c_interop/include/whisper_stt.h
@@ -5,9 +5,10 @@ extern "C" {
 #endif
 
 int whisper_stt_init(const char* model_path);
-const char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt);
-const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int translate, int diarize);
+char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt);
+char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int translate, int diarize);
 void whisper_stt_release(void);
+void whisper_stt_free_string(char* p);
 
 #ifdef __cplusplus
 }

--- a/library/src/commonMain/cpp/whisper_jni.cpp
+++ b/library/src/commonMain/cpp/whisper_jni.cpp
@@ -103,13 +103,14 @@ Java_com_llamatik_library_platform_WhisperBridge_transcribeWav(JNIEnv* env, jobj
     const char* clang = lang ? env->GetStringUTFChars(lang, nullptr) : nullptr;
     const char* cprompt = initialPrompt ? env->GetStringUTFChars(initialPrompt, nullptr) : nullptr;
 
-    const char* out = whisper_stt_transcribe_wav(cwav, clang, cprompt);
+    char* out = whisper_stt_transcribe_wav(cwav, clang, cprompt);
 
     if (initialPrompt) env->ReleaseStringUTFChars(initialPrompt, cprompt);
     if (lang) env->ReleaseStringUTFChars(lang, clang);
     env->ReleaseStringUTFChars(wavPath, cwav);
 
     std::string safe = sanitize_for_modified_utf8(out ? out : "");
+    whisper_stt_free_string(out);
     return env->NewStringUTF(safe.c_str());
 }
 
@@ -119,13 +120,14 @@ Java_com_llamatik_library_platform_WhisperBridge_transcribeWavSegments(JNIEnv* e
     const char* clang = lang ? env->GetStringUTFChars(lang, nullptr) : nullptr;
     const char* cprompt = initialPrompt ? env->GetStringUTFChars(initialPrompt, nullptr) : nullptr;
 
-    const char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt, translate ? 1 : 0, diarize ? 1 : 0);
+    char* out = whisper_stt_transcribe_wav_segments(cwav, clang, cprompt, translate ? 1 : 0, diarize ? 1 : 0);
 
     if (initialPrompt) env->ReleaseStringUTFChars(initialPrompt, cprompt);
     if (lang) env->ReleaseStringUTFChars(lang, clang);
     env->ReleaseStringUTFChars(wavPath, cwav);
 
     std::string safe = sanitize_for_modified_utf8(out ? out : "");
+    whisper_stt_free_string(out);
     return env->NewStringUTF(safe.c_str());
 }
 

--- a/library/src/commonMain/cpp/whisper_stt.cpp
+++ b/library/src/commonMain/cpp/whisper_stt.cpp
@@ -7,13 +7,12 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
 
 #include "whisper.h"
 
 static std::mutex g_mu;
 static whisper_context* g_ctx = nullptr;
-static std::string g_last;
-static std::string g_segments_json;
 
 int whisper_stt_init(const char* model_path) {
     std::lock_guard<std::mutex> lock(g_mu);
@@ -114,19 +113,16 @@ static bool load_wav_pcm16_mono_16k(const char* path, std::vector<float>& out) {
     return true;
 }
 
-const char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt) {
+char* whisper_stt_transcribe_wav(const char* wav_path, const char* language, const char* initial_prompt) {
     std::lock_guard<std::mutex> lock(g_mu);
-    g_last.clear();
 
     if (!g_ctx) {
-        g_last = "ERROR: Whisper not initialized";
-        return g_last.c_str();
+        return ::strdup("ERROR: Whisper not initialized");
     }
 
     std::vector<float> pcmf;
     if (!load_wav_pcm16_mono_16k(wav_path, pcmf)) {
-        g_last = "ERROR: WAV must be PCM16 mono 16kHz";
-        return g_last.c_str();
+        return ::strdup("ERROR: WAV must be PCM16 mono 16kHz");
     }
 
     whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
@@ -137,6 +133,8 @@ const char* whisper_stt_transcribe_wav(const char* wav_path, const char* languag
 
     if (language && language[0]) {
         params.language = language;
+    } else {
+        params.language = "auto";
     }
 
     if (initial_prompt && initial_prompt[0]) {
@@ -144,17 +142,17 @@ const char* whisper_stt_transcribe_wav(const char* wav_path, const char* languag
     }
 
     if (whisper_full(g_ctx, params, pcmf.data(), (int)pcmf.size()) != 0) {
-        g_last = "ERROR: whisper_full failed";
-        return g_last.c_str();
+        return ::strdup("ERROR: whisper_full failed");
     }
 
+    std::string result;
     const int n = whisper_full_n_segments(g_ctx);
     for (int i = 0; i < n; i++) {
         const char* seg = whisper_full_get_segment_text(g_ctx, i);
-        if (seg) g_last += seg;
+        if (seg) result += seg;
     }
 
-    return g_last.c_str();
+    return ::strdup(result.c_str());
 }
 
 // Minimal JSON string-content escaper (appends escaped [s] into [out]).
@@ -196,73 +194,64 @@ static void json_escape(const char* s, std::string& out) {
 //   ]}
 // t0/t1 are milliseconds. speaker_turn_next is meaningful only with a tinydiarize
 // (…-tdrz) model; it is always false for regular models (never throws).
-const char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int translate, int diarize) {
+char* whisper_stt_transcribe_wav_segments(const char* wav_path, const char* language, const char* initial_prompt, int translate, int diarize) {
     std::lock_guard<std::mutex> lock(g_mu);
-    g_segments_json.clear();
 
     if (!g_ctx) {
-        g_segments_json = "{\"error\":\"Whisper not initialized\"}";
-        return g_segments_json.c_str();
+        return ::strdup("{\"error\":\"Whisper not initialized\"}");
     }
 
     std::vector<float> pcmf;
     if (!load_wav_pcm16_mono_16k(wav_path, pcmf)) {
-        g_segments_json = "{\"error\":\"WAV must be PCM16 mono 16kHz\"}";
-        return g_segments_json.c_str();
+        return ::strdup("{\"error\":\"WAV must be PCM16 mono 16kHz\"}");
     }
 
     whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
     params.print_progress = false;
     params.print_realtime = false;
     params.print_timestamps = false;
-    // [translate] whisper's built-in ORIGINAL→ENGLISH translation task. When true,
-    // segment text is the ENGLISH translation regardless of the spoken language — a
-    // real Whisper translation (not an LLM paraphrase). Off = language-preserving.
     params.translate = translate != 0;
-    // [EXPERIMENTAL][TDRZ] enable tinydiarize speaker-turn detection — only meaningful
-    // with a `…-tdrz` model. Off by default so regular models are unaffected (a tdrz
-    // model additionally emits `[SPEAKER_TURN]` markers in the text, so callers gate this
-    // to tdrz models only).
     params.tdrz_enable = diarize != 0;
 
     if (language && language[0]) {
         params.language = language;
+    } else {
+        params.language = "auto";
     }
     if (initial_prompt && initial_prompt[0]) {
         params.initial_prompt = initial_prompt;
     }
 
     if (whisper_full(g_ctx, params, pcmf.data(), (int)pcmf.size()) != 0) {
-        g_segments_json = "{\"error\":\"whisper_full failed\"}";
-        return g_segments_json.c_str();
+        return ::strdup("{\"error\":\"whisper_full failed\"}");
     }
 
     const int lang_id = whisper_full_lang_id(g_ctx);
     const char* lang_str = (lang_id >= 0) ? whisper_lang_str(lang_id) : "";
 
-    g_segments_json = "{\"language\":\"";
-    json_escape(lang_str ? lang_str : "", g_segments_json);
-    g_segments_json += "\",\"segments\":[";
+    std::string result = "{\"language\":\"";
+    json_escape(lang_str ? lang_str : "", result);
+    result += "\",\"segments\":[";
 
     const int n = whisper_full_n_segments(g_ctx);
     for (int i = 0; i < n; i++) {
-        if (i > 0) g_segments_json += ",";
+        if (i > 0) result += ",";
         const char* seg = whisper_full_get_segment_text(g_ctx, i);
         const long long t0 = static_cast<long long>(whisper_full_get_segment_t0(g_ctx, i)) * 10; // csec → msec
         const long long t1 = static_cast<long long>(whisper_full_get_segment_t1(g_ctx, i)) * 10;
         const bool turn = whisper_full_get_segment_speaker_turn_next(g_ctx, i);
 
-        g_segments_json += "{\"text\":\"";
-        json_escape(seg ? seg : "", g_segments_json);
+        result += "{\"text\":\"";
+        json_escape(seg ? seg : "", result);
         char buf[96];
         std::snprintf(buf, sizeof(buf),
                       "\",\"t0\":%lld,\"t1\":%lld,\"speaker_turn_next\":%s}",
                       t0, t1, turn ? "true" : "false");
-        g_segments_json += buf;
+        result += buf;
     }
-    g_segments_json += "]}";
+    result += "]}";
 
-    return g_segments_json.c_str();
+    return ::strdup(result.c_str());
 }
 
 void whisper_stt_release(void) {
@@ -271,4 +260,8 @@ void whisper_stt_release(void) {
         whisper_free(g_ctx);
         g_ctx = nullptr;
     }
+}
+
+void whisper_stt_free_string(char* p) {
+    if (p) std::free(p);
 }

--- a/library/src/iosMain/cpp/whisper_stt.cpp
+++ b/library/src/iosMain/cpp/whisper_stt.cpp
@@ -109,6 +109,7 @@ static bool read_wav_pcm16le_to_f32_mono(const char *path, std::vector<float> &o
     if (!have_fmt || !have_data) return false;
     if (audio_format != 1) return false;      // PCM only
     if (bits_per_sample != 16) return false;  // PCM16 only
+    if (sample_rate != 16000) return false;   // whisper requires 16kHz
     if (num_channels < 1 || num_channels > 2) return false;
 
     const size_t frame_size = (size_t)num_channels * 2;

--- a/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/com/llamatik/library/platform/WhisperBridge.wasmJs.kt
@@ -3,8 +3,7 @@ package com.llamatik.library.platform
 actual object WhisperBridge {
     actual fun getModelPath(modelFileName: String): String = "/models/$modelFileName"
     actual fun initModel(modelPath: String): Boolean = false
-    actual fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String =
-        "Whisper WASM not wired yet."
+    actual fun transcribeWav(wavPath: String, language: String?, initialPrompt: String?): String = ""
     actual fun transcribeWavSegments(wavPath: String, language: String?, initialPrompt: String?, translate: Boolean, diarize: Boolean): String =
         "{\"language\":\"\",\"segments\":[]}"
     actual fun release() {}


### PR DESCRIPTION
Fix 1 — JNI race condition (whisper_jni.cpp): Both JNI wrappers now capture the result into a local char*, copy it into a std::string for sanitization, then call
  whisper_stt_free_string(out) — the pointer is consumed entirely before the next call can touch it.

  Fix 2 — Language auto-detection (commonMain/cpp/whisper_stt.cpp): Both transcribeWav and transcribeWavSegments now have an else { params.language = "auto"; } branch, matching
  iOS behavior when no language is specified.

  Fix 3 — Memory ownership contract (commonMain/c_interop/include/whisper_stt.h + commonMain/cpp/whisper_stt.cpp): Both Android transcription functions now return char* via
  ::strdup (heap-allocated, caller-freed), matching the iOS convention. whisper_stt_free_string is added to the Android implementation and exposed in the header. The static
  globals g_last and g_segments_json are gone.

  Fix 4 — iOS sample rate validation (iosMain/cpp/whisper_stt.cpp:112): Added if (sample_rate != 16000) return false; to read_wav_pcm16le_to_f32_mono — same guard that existed on
  Android.

  Fix 5 — WASM inconsistency (wasmJsMain/kotlin/WhisperBridge.wasmJs.kt): transcribeWav stub now returns "" instead of "Whisper WASM not wired yet.", consistent with the
  JSON-returning transcribeWavSegments stub and safe for any caller that checks for empty string.
