### PR TITLE
feat(build): pass extra CMake flags to native builds via llamatik.cmake.args

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ git clone --recurse-submodules https://github.com/ferranpons/llamatik.git
 
 Each native dependency (`llama.cpp`, `whisper.cpp`, `stable-diffusion.cpp`) is included as a Git submodule. Run `git submodule update --init --recursive` if you cloned without `--recurse-submodules`.
 
+### Extra CMake flags
+
+The native builds (Apple, desktop JNI, Android) accept additional CMake configure flags through the `llamatik.cmake.args` Gradle property, with the `LLAMATIK_CMAKE_ARGS` environment variable as a fallback. Values are split on whitespace and appended to the CMake command line, so flags containing spaces are not supported. This lets you enable GPU backends without editing the build script:
+
+```bash
+# Build with the Vulkan backend enabled
+./gradlew :library:build -Pllamatik.cmake.args="-DGGML_VULKAN=ON"
+
+# Or via the environment
+LLAMATIK_CMAKE_ARGS="-DGGML_CUDA=ON" ./gradlew :library:build
+```
+
+The WASM build does not receive these flags since GPU backends do not apply to the Emscripten target.
+
 ## Pull Request Guidelines
 
 1. **Branch from `main`** — use a descriptive branch name, e.g. `fix/session-leak` or `feat/wasm-streaming`

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -30,6 +30,19 @@ fun existingDir(path: String?): String? {
     return if (f.exists() && f.isDirectory) f.absolutePath else null
 }
 
+// Extra flags appended to the native CMake configure steps (Apple, desktop JNI,
+// Android), so backends like Vulkan or CUDA can be enabled without editing this
+// script, e.g.:
+//   ./gradlew :library:build -Pllamatik.cmake.args="-DGGML_VULKAN=ON"
+// Falls back to the LLAMATIK_CMAKE_ARGS environment variable (same precedent as
+// LLAMATIK_SKIP_NATIVE_BUILD). Values are split on whitespace, so flags that
+// contain spaces are not supported.
+val extraCmakeArgs: List<String> =
+    (propString("llamatik.cmake.args") ?: System.getenv("LLAMATIK_CMAKE_ARGS"))
+        ?.split(Regex("\\s+"))
+        ?.filter { it.isNotBlank() }
+        .orEmpty()
+
 // Resolve EMSDK root in a way that works in Android Studio (no shell env needed).
 fun Project.resolveEmsdkRoot(): String? {
     // 1) Gradle properties (IDE-safe)
@@ -220,7 +233,7 @@ kotlin {
                         "-DLLAMA_CURL=OFF",
                         if (sdk == "iphonesimulator") "-DLLAMA_BUILD_BERT=ON" else "-DLLAMA_BUILD_BERT=OFF",
                         if (sdk == "iphonesimulator") "-DLLAMA_BUILD_EMBEDDERS=ON" else "-DLLAMA_BUILD_EMBEDDERS=OFF",
-                    )
+                    ) + extraCmakeArgs
                 }
             }
 
@@ -442,6 +455,8 @@ kotlin {
                 args += listOf("-DCMAKE_SYSTEM_NAME=Darwin")
             }
 
+            args += extraCmakeArgs
+
             commandLine(args)
         }
     }
@@ -608,6 +623,9 @@ kotlin {
                 args += "-DCMAKE_EXE_LINKER_FLAGS=$wasmLinkFlags"
             }
 
+            // extraCmakeArgs is intentionally not applied here: it exists mainly
+            // for GPU backend flags, which do not apply to the Emscripten build.
+
             commandLine(args)
         }
     }
@@ -664,6 +682,11 @@ extensions.configure<LibraryExtension> {
         minSdk = libs.versions.android.minSdk.get().toInt()
         ndk {
             abiFilters += setOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
+        }
+        externalNativeBuild {
+            cmake {
+                arguments += extraCmakeArgs
+            }
         }
         consumerProguardFiles("consumer-rules.pro")
     }


### PR DESCRIPTION
### Pass extra CMake flags to native builds via llamatik.cmake.args

Today the CMake argument lists in `library/build.gradle.kts` are fixed, so
building from source always produces CPU-only natives everywhere except macOS
(where Metal is default-on). Enabling a GPU backend like Vulkan or CUDA means
editing the build script or maintaining a fork.

This PR adds a single pass-through: the `llamatik.cmake.args` Gradle property
(or the `LLAMATIK_CMAKE_ARGS` environment variable, following the
`LLAMATIK_SKIP_NATIVE_BUILD` precedent). Its whitespace-separated values are
appended to the CMake configure arguments for the Apple/iOS wrapper build, the
desktop JNI build, and the Android `externalNativeBuild`. The WASM/Emscripten
build is intentionally excluded since GPU backends do not apply there. Example:

```
./gradlew :library:build -Pllamatik.cmake.args="-DGGML_VULKAN=ON"
```

- No behavior changes when the property is unset.
- Documented in CONTRIBUTING.md under Development Setup.
- Verified project configuration succeeds with the property set, with the env
  fallback, and with neither (exercises the AGP `defaultConfig` block).
- Motivating use case: building Vulkan-enabled desktop natives for a
  downstream Kotlin Multiplatform SDK without carrying a fork.

One known limitation, happy to follow up if wanted: the iOS `mergeLlamaStatic*`
step merges a hardcoded list of ggml archives, so iOS builds that produce
additional backend archives would need that list extended. This does not
affect desktop or Android GPU builds.
